### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 # Zelos
 Zelos is a Python-based binary emulation platform. Linux x86, x86_64, ARMv7 and MIPS binaries are supported.
 
+## Documentation
+
+All of the documentation can be found on [readthedocs](https://zelos.readthedocs.io/en/latest/index.html)
+
 ## Installation
 
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install zelos.

--- a/docs/tutorials/02_scripting.md
+++ b/docs/tutorials/02_scripting.md
@@ -251,7 +251,7 @@ Yet again, to check our script, we can see that the last four lines of the outpu
 ## Scripting Tutorial - Brute
 
 The source code and test program for this tutorial can be found at
-https://github.com/zeropointdynamics/zelos/tree/master/examples/simple_brute
+[examples/script_brute](https://github.com/zeropointdynamics/zelos/tree/master/examples/script_brute)
 
 This example demonstrates some more of the dynamic capabilities of zelos. Consider the following example binary:
 

--- a/docs/tutorials/03_using_hooks.md
+++ b/docs/tutorials/03_using_hooks.md
@@ -12,7 +12,7 @@ Hooks are a way to invoke your code whenever certain events occur during executi
 *  Invocations of syscalls use :py:meth:`~zelos.Zelos.hook_syscalls`
 *  Execution of an instruction :py:meth:`~zelos.Zelos.hook_execution`
 
-Each hook offers different configuration options and requires a different type of callback. For more details, as well as examples, for each type of hook, look at the :py:class:`~zelos.Zelos`.
+Each hook offers different configuration options and requires a different type of callback. For more details, as well as examples, for each type of hook, take a look at :py:class:`~zelos.Zelos`.
 ```
 
 ## Pwnable.kr Challenge

--- a/docs/tutorials/04_writing_plugins.md
+++ b/docs/tutorials/04_writing_plugins.md
@@ -47,7 +47,7 @@ class MinimalPlugin(IPlugin):
         print("Minimal plugin is created.")
 ```
 ```eval_rst
-Now, we add the :py:class:`zelos.CommandLineOption` to change behavior at run time. The option can then be accessed using :py:class`zelos.Zelos`'s :code:`config` field.
+Now, we add the :py:class:`zelos.CommandLineOption` to change behavior at run time. The option can then be accessed using :py:class:`zelos.Zelos`'s :code:`config` field.
 ```
 
 ```python

--- a/docs/tutorials/05_syscall_limit_plugin.md
+++ b/docs/tutorials/05_syscall_limit_plugin.md
@@ -77,7 +77,7 @@ class SyscallLimiter(IPlugin):
 ## Implementing the Syscall Hook
 
 ```eval_rst
-In order to implement the desired behavior of SyscallLimiter, we create a syscall hook using the :py:meth:`~zelos.Zelos.hook_syscalls` function. As noted in the previous tutorial, we can access our command line options through :py:class`zelos.Zelos`'s :code:`config` field. Additionally, we create a callback function that keeps track of the number of syscalls executed overall and per thread.
+In order to implement the desired behavior of SyscallLimiter, we create a syscall hook using the :py:meth:`~zelos.Zelos.hook_syscalls` function. As noted in the previous tutorial, we can access our command line options through :py:class:`zelos.Zelos`'s :code:`config` field. Additionally, we create a callback function that keeps track of the number of syscalls executed overall and per thread.
 ```
 
 ```python

--- a/examples/script_brute/README.md
+++ b/examples/script_brute/README.md
@@ -1,7 +1,7 @@
 ## Scripting Tutorial - Brute
 
 The source code and test program for this tutorial can be found at
-https://github.com/zeropointdynamics/zelos/tree/master/examples/simple_brute
+[examples/script_brute](https://github.com/zeropointdynamics/zelos/tree/master/examples/script_brute)
 
 This example demonstrates some more of the dynamic capabilities of zelos. Consider the following example binary:
 

--- a/examples/script_brute/README.md
+++ b/examples/script_brute/README.md
@@ -1,9 +1,9 @@
-## Simple Brute Tutorial
+## Scripting Tutorial - Brute
 
 The source code and test program for this tutorial can be found at
-https://github.com/zeropointdynamics/zelos/tree/master/examples/script_brute
+https://github.com/zeropointdynamics/zelos/tree/master/examples/simple_brute
 
-This example demonstrates some of the dynamic capabilities of zelos. Consider the following example binary:
+This example demonstrates some more of the dynamic capabilities of zelos. Consider the following example binary:
 
 ```sh
 $ ./password.bin
@@ -33,13 +33,10 @@ We start with a script that loads the binary and emulates normal behavior:
 ```python
 from zelos import Zelos
 
-
 def brute():
-    z = Zelos("password.bin")
-    z.set_verbose(True)
+    z = Zelos("password.bin", verbosity=1)
     # Start execution
     z.start()
-
 
 if __name__ == "__main__":
     brute()
@@ -71,23 +68,19 @@ from zelos import Zelos
 
 
 def brute():
-    z = Zelos("password.bin")
-    z.set_verbose(True)
+    z = Zelos("password.bin", verbosity=1)
     # The address of strcmp observed above
     strcmp_address = 0x00400BB6
     # run to the address of call to strcmp and stop
     z.plugins.runner.run_to_addr(strcmp_address)
-
     # Execution is now STOPPED at address 0x00400BB6
 
-    # Get the current process
-    p = z.current_process
     # get initial reg values of rdi & rsi before strcmp is called
-    rdi = p.emu.get_reg("rdi") # user input
-    rsi = p.emu.get_reg("rsi") # 'real' password
+    rdi = z.regs.rdi # user input
+    rsi = z.regs.rsi # 'real' password
 
     # Write the string "our best guess" to address in rdi
-    p.memory.write_string(rdi, "our best guess")
+    z.memory.write_string(rdi, "our best guess")
 
     # Resume execution
     z.start()
@@ -140,26 +133,22 @@ from zelos import Zelos
 
 
 def brute():
-    z = Zelos("password.bin")
-    z.set_verbose(True)
+    z = Zelos("password.bin", verbosity=1)
     # The address of strcmp observed above
     strcmp_address = 0x00400BB6
     # run to the address of call to strcmp and stop
     z.plugins.runner.run_to_addr(strcmp_address)
-
     # Execution is now STOPPED at address 0x00400BB6
 
-    # Get the current process
-    p = z.current_process
     # get initial reg values of rdi & rsi before strcmp is called
-    rdi = p.current_thread.get_reg("rdi")  # user input
-    rsi = p.current_thread.get_reg("rsi")  # 'real' password
+    rdi = z.regs.rdi # user input
+    rsi = z.regs.rsi # 'real' password
 
     # 'brute force' the correct string
     for i in range(9, -1, -1):
 
         # write our bruteforced guess to memory
-        p.memory.write_string(rdi, str(i) + "point")
+        z.memory.write_string(rdi, str(i) + "point")
 
         # Address of the test instr
         test_address = 0x00400BBB
@@ -169,7 +158,7 @@ def brute():
         z.step()
 
         # check the zf bit for result of test
-        flags = p.current_thread.get_reg("flags")
+        flags = z.regs.flags
         zf = (flags & 0x40) >> 6
         if zf == 1:
             # if correct, run to completion
@@ -177,9 +166,9 @@ def brute():
             return
 
         # otherwise, reset ip to strcmp func & set regs
-        p.current_thread.setIP(strcmp_address)
-        p.current_thread.set_reg("rdi", rdi)
-        p.current_thread.set_reg("rsi", rsi)
+        z.regs.setIP(strcmp_address)
+        z.regs.rdi = rdi
+        z.regs.rsi = rsi
 
 
 if __name__ == "__main__":

--- a/examples/script_bypass/README.md
+++ b/examples/script_bypass/README.md
@@ -1,7 +1,6 @@
 ## Scripting Tutorial - Bypass
 
-The source code for this tutorial can be found at
-https://github.com/zeropointdynamics/zelos/tree/master/examples/script_bypass
+The source code and test program for this tutorial can be found in the [examples/script_bypass](https://github.com/zeropointdynamics/zelos/tree/master/examples/script_bypass) directory.
 
 Consider the following example binary:
 
@@ -22,24 +21,20 @@ entry of the correct password, the program will output "Correct!" to
 stdout and exit. Upon entry of an incorrect password, however, the
 program will output "Incorrect" to stdout.
 
-Let's say that our objective is to bypass the password check, such that
+Our objective is to bypass the password check, such that
 any password can be entered and the program will always print "Correct!"
 to stdout. For this tutorial we will accomplish this in three different ways,
 by dynamically writing directly to memory, setting registers, and patching code.
 
-For each of these, we start with a script that loads the binary
+For each of these, we start with a boilerplate script that loads the binary
 and emulates normal behavior:
 
 ```python
 from zelos import Zelos
 
-
 def main():
-    z = Zelos("password_check.bin")
-    z.set_verbose(True)
-    # Start execution
+    z = Zelos("password_check.bin", verbosity=1)
     z.start()
-
 
 if __name__ == "__main__":
     main()
@@ -96,8 +91,7 @@ To bypass this, we can ensure that this jump is never taken by writing
 
 ```python
 def patch_mem():
-    z = Zelos("password_check.bin")
-    # z.set_verbose(True)
+    z = Zelos("password_check.bin", verbosity=1)
     # The address cmp instr observed above
     target_address = 0x0040107C
     # run to the target address and stop
@@ -105,12 +99,8 @@ def patch_mem():
 
     # Execution is now STOPPED at address 0x0040107C
 
-    # Get the current process
-    p = z.current_process
-    # Get the value of rbp
-    rbp = p.emu.get_reg("rbp")
     # Write 0x0 to address [rbp - 0x38]
-    p.memory.write_int(rbp - 0x38, 0x0)
+    z.memory.write_int(z.regs.rbp - 0x38, 0x0)
     # resume execution
     z.start()
 
@@ -136,19 +126,15 @@ it is used.
 
 ```python
 def patch_reg():
-    z = Zelos("password_check.bin")
-    # z.set_verbose(True)
+    z = Zelos("password_check.bin", verbosity=1)
     # The address of the first time eax is used above
     target_address = 0x00401810
     # run to the target address and stop
     z.plugins.runner.run_to_addr(target_address)
-
     # Execution is now STOPPED at address 0x00401810
 
-    # Get the current process
-    p = z.current_process
     # Set eax to 0x0
-    p.current_thread.set_reg("eax", 0x0)
+    z.eax = 0x0
     # Resume execution
     z.start()
 
@@ -179,8 +165,7 @@ also includes two NOP instructions since we are replacing a 4 byte instruction.
 
 ```python
 def patch_code():
-    z = Zelos("password_check.bin")
-    # z.set_verbose(True)
+    z = Zelos("password_check.bin", verbosity=1)
     # The address of the cmp instr
     target_address = 0x0040107C
     # run to the address of cmp and stop
@@ -188,8 +173,6 @@ def patch_code():
 
     # Execution is now STOPPED at address 0x0040107C
 
-    # Get the current process
-    p = z.current_process
 
     # Code we want to insert
     code = b"NOP; NOP; CMP eax, eax"
@@ -199,7 +182,7 @@ def patch_code():
 
     # replace the four bytes at this location with our code
     for i in range(len(encoding)):
-        p.memory.write_uint8(target_address + i, encoding[i])
+        z.memory.write_uint8(target_address + i, encoding[i])
 
     # resume execution
     z.start()

--- a/examples/script_bypass/README.md
+++ b/examples/script_bypass/README.md
@@ -1,6 +1,7 @@
 ## Scripting Tutorial - Bypass
 
-The source code and test program for this tutorial can be found in the [examples/script_bypass](https://github.com/zeropointdynamics/zelos/tree/master/examples/script_bypass) directory.
+The source code and test program for this tutorial can be found in the
+[examples/script_bypass](https://github.com/zeropointdynamics/zelos/tree/master/examples/script_bypass) directory.
 
 Consider the following example binary:
 

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -28,7 +28,11 @@ from zelos.plugin import Plugins
 
 
 class Zelos:
-    """ API class that provides access to interal api wrappers. """
+    """
+    Class that provides access to core api wrappers. These core APIs
+    are event hooking, debugging, memory access, register access, and
+    emulation context.
+    """
 
     def __init__(self, filename, *cmdline_args, **flags):
         config = generate_config(filename, *cmdline_args, **flags)
@@ -254,7 +258,10 @@ class Zelos:
 
     def start(self, timeout: float = 0) -> None:
         """
-        Begin emulation, starting execution at the IP.
+        Begin emulation. When called for the first time, begins
+        execution at the binary entry point. If the emulation is
+        stopped (for example, after calling :py:meth:`stop()`) this
+        will resume execution from the current IP.
 
         Args:
             timeout: Stops execution after `timeout` seconds.
@@ -266,6 +273,7 @@ class Zelos:
 
                 z = ("binary_to_emulate")
 
+                # Start execution from the entry point
                 z.start()
 
         """
@@ -283,7 +291,9 @@ class Zelos:
 
     def stop(self, reason: str = "plugin"):
         """
-        Stop the Zelos run loop and end execution.
+        Stop the Zelos run loop. After a call to
+        :py:meth:`stop()`, execution can be resumed from the
+        current IP with a call to :py:meth:`start()`.
 
         Args:
             reason: An optional identifier that specifies a reason for

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -25,6 +25,8 @@ from zelos.config_gen import generate_config, generate_config_from_cmdline
 from zelos.engine import Engine
 from zelos.hooks import HookInfo, HookType
 from zelos.plugin import Plugins
+from zelos.processes import Process
+from zelos.threads import Thread
 
 
 class Zelos:
@@ -311,7 +313,10 @@ class Zelos:
         self.internal_engine.close()
 
     def end_thread(self):
-        """ Stop the current thread. Mark as successfully completed."""
+        """
+        End the current thread. Marks current thread as successfully
+        completed and swaps to the next available thread, if one exists.
+        """
         self.internal_engine.thread_manager.complete_current_thread()
 
     def swap_thread(self, reason: str = "thread swap"):
@@ -528,7 +533,14 @@ class Zelos:
 
     @property
     def date(self):
-        """ Returns the date used internally during emulation. """
+        """
+        Returns the date string used internally during emulation. The
+        date string format is `YYYY-MM-DD`.
+
+        :getter: Returns the date string in YYYY-MM-DD format.
+        :setter: Sets the date string. Input must be YYYY-MM-DD format.
+        :type: str
+        """
         return self.internal_engine.date
 
     @date.setter
@@ -556,13 +568,25 @@ class Zelos:
         self.internal_engine.date = date_str
 
     @property
-    def process(self):
-        """ Returns the active process"""
+    def process(self) -> Process:
+        """
+        Returns the currently active process.
+
+        :getter: Return the current process object.
+        :type: Process
+
+        """
         return self.internal_engine.current_process
 
     @property
-    def thread(self):
-        """ Returns the active thread"""
+    def thread(self) -> Thread:
+        """
+        Returns the currently active thread.
+
+        :getter: Returns the current thread object.
+        :type: Thread
+
+        """
         return self.internal_engine.current_process.current_thread
 
 

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -42,8 +42,8 @@ class Zelos:
 
     def _setup(self, config):
         self.config = config
-        self.regs = RegsApi(self)
-        self.memory = MemoryApi(self)
+        self._regs = RegsApi(self)
+        self._memory = MemoryApi(self)
 
         self._breakpoints = {}
         self._watchpoints = defaultdict(dict)
@@ -54,6 +54,22 @@ class Zelos:
         Engine(config=config, api=self)
         self.plugins = Plugins(self, ["plugins"])
         self.internal_engine.plugins = self.plugins
+
+    # **** Memory API ****
+    @property
+    def memory(self):
+        """
+        Returns the :py:class:`~zelos.api.memory_api.MemoryApi` object.
+        """
+        return self._memory
+
+    # **** Registers API ****
+    @property
+    def regs(self):
+        """
+        Returns the :py:class:`~zelos.api.regs_api.RegsApi` object.
+        """
+        return self._regs
 
     # **** Begin Hook API ****
     def hook_memory(

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -572,7 +572,6 @@ class Zelos:
         """
         Returns the currently active process.
 
-        :getter: Return the current process object.
         :type: Process
 
         """
@@ -583,7 +582,6 @@ class Zelos:
         """
         Returns the currently active thread.
 
-        :getter: Returns the current thread object.
         :type: Thread
 
         """


### PR DESCRIPTION
-  Remove 'Simple' from "Brute" README
- Fix hyperlinks in 01 Brute Tutorial
- In 'Using Hooks' tutorial, fix typo: "look at the Zelos."
- In 'Writing Plugins' tutorial, fix type: "accessed using :py:class`zelos.Zelos`’s config field"
- In syscall limiter tutorial: fix typo:  ":py:class`zelos.Zelos`’s config field"
- In zelos api docs:
  - Document the Zelos() init arguments.
  - Replace "API class that provides access to interal api wrappers." with a description of what Zelos provides (emulation, hooking, etc.).
  - Fix reference to zelos.Engine.close() (replace `Engine` with `Zelos`)
  - "Begin emulation, starting execution at the IP.", should this be "at the binary entry point"?
  - "Stop the Zelos run loop and end execution.". This is confusing, since `end_thread` exits a thread, whereas one can continue from a stop. Update language and clarify, maybe explicitly say execution can be started again.
  - "Stop the current thread. Mark as successfully completed.". `stop` and `end` may be getting overloaded. Clarify.
  - Describe the date format.
  - Give the type for all properties
  - `regs` and `memory` are not showing up as properties.