### PR TITLE
Allow hooks on unmapped memory to be run correctly

### DIFF
--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -385,7 +385,7 @@ class Hooks:
             "Missing memory at 0x%x, IP = 0x%x data size = %u, "
             "data value = 0x%x" % (address, eip, size, value)
         )
-        return True  # Stop executing
+        return False  # Returning False allows other hooks to execute
 
     def add_hook(
         self,

--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -385,7 +385,7 @@ class Hooks:
             "Missing memory at 0x%x, IP = 0x%x data size = %u, "
             "data value = 0x%x" % (address, eip, size, value)
         )
-        return False  # Returning False allows other hooks to execute
+        return False  # Returning False allows other hooks to execute.
 
     def add_hook(
         self,


### PR DESCRIPTION
Returning `True` on a hook for unmapped memory causes other hooks to not be run. Added a test to ensure that other `MEMORY.UNMAPPED` will run.