### PR TITLE
Introduce a Next function in api, similar to GDB

### DIFF
--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -327,6 +327,17 @@ class Zelos:
         """
         self.internal_engine.step(count=count)
 
+    def next(self, count=1) -> None:
+        """
+        Begin emulation, executing `count` instructions not including
+        instructions inside function calls.
+
+        Args:
+            count: Maximum number of instructions to execute before
+                stopping.
+        """
+        self.internal_engine.step_over(count=count)
+
     def stop(self, reason: str = "plugin"):
         """
         Stop the Zelos run loop. After a call to

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -475,10 +475,6 @@ class Engine:
     def step(self, count: int = 1) -> None:
         """ Steps one assembly level instruction """
         self.start(count=count, swap_threads=False)
-        if self.last_instruction is not None:
-            self.trace.bb(self.last_instruction, self.last_instruction_size)
-        else:
-            self.trace.bb()
 
     def step_over(self, count: int = 1) -> None:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -160,11 +160,27 @@ class ZelosTest(unittest.TestCase):
 
     def test_step(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))
-        addr = 0x0816348F
+        addr = 0x080EC3F0  # Call, should step into it
         z.plugins.runner.run_to_addr(addr)
         self.assertEqual(z.thread.getIP(), addr)
         z.step()
-        self.assertEqual(z.thread.getIP(), 0x08163492)
+        self.assertEqual(
+            z.thread.getIP(),
+            0x08048DBD,
+            f"{z.thread.getIP():x} vs. {0x08048DBD:x}",
+        )
+
+    def test_next(self):
+        z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))
+        addr = 0x080EC3F0  # Call, should step over it.
+        z.plugins.runner.run_to_addr(addr)
+        self.assertEqual(z.thread.getIP(), addr)
+        z.next()
+        self.assertEqual(
+            z.thread.getIP(),
+            0x080EC3F5,
+            f"{z.thread.getIP():x} vs. {0x080EC3F5:x}",
+        )
 
     def test_stop(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))


### PR DESCRIPTION
This will allow stepping by instruction without stepping into function calls. "Next" was chosen due to its usage in GDB