### PR TITLE
Correct behavior of step in verbose mode.

### DIFF
--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -534,7 +534,7 @@ class Engine:
             self.step()
         return True
 
-    def start(self, count=0, timeout=0, swap_threads=True) -> None:
+    def start(self, timeout=0, swap_threads=True) -> None:
         """
         Starts execution of the program at the given offset or entry
         point.
@@ -573,7 +573,7 @@ class Engine:
                     )
                 else:
                     # Execute until emulator exception
-                    self._run(self.current_process, count)
+                    self._run(self.current_process)
             except UcError as e:
                 # TODO: This is a special case for forcing a stop.
                 # Sometimes setting a stop reason doesn't stop
@@ -597,7 +597,7 @@ class Engine:
 
         return
 
-    def _run(self, p, count):
+    def _run(self, p):
         t = p.current_thread
         assert (
             t is not None
@@ -611,7 +611,7 @@ class Engine:
 
         t.emu.is_running = True
         try:
-            t.emu.emu_start(t.getIP(), 0, count=count)
+            t.emu.emu_start(t.getIP(), 0)
         finally:
             stop_addr = p.threads.scheduler._pop_stop_addr(t.id)
             t.emu.is_running = False

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -496,15 +496,11 @@ class Engine:
 
         self.should_print_last_instruction = False
         inst_count = 0
-        print("Starting step ", inst_count)
-        start_address = self.current_thread.id
 
         def step_n(zelos, addr, size):
-            nonlocal inst_count, start_address
+            nonlocal inst_count
             inst_count += 1
-            print(f"step {start_address:x} {zelos.thread} {inst_count}")
             if inst_count > count:
-                print(f"stop {addr:x}")
                 self.scheduler.stop("step")
 
         def quit_step_n():

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -17,7 +17,7 @@
 import unittest
 
 from os import path
-from unittest.mock import ANY, Mock
+from unittest.mock import Mock, call
 
 from zelos import Zelos
 from zelos.hooks import HookType
@@ -171,10 +171,11 @@ class HookManagerTest(unittest.TestCase):
         hook_info = z.hook_execution(
             HookType.EXEC.INST, mock_hook, name="test_hook"
         )
-
         mock_hook.assert_not_called()
         z.step()
-        mock_hook.assert_called_once()
+        mock_hook.assert_has_calls(
+            [call(z, 0x8048B70, 2), call(z, 0x8048B72, 1)]
+        )
         mock_hook.reset_mock()
 
         pid = z.internal_engine.processes.new_process("test_process")
@@ -188,7 +189,9 @@ class HookManagerTest(unittest.TestCase):
         )
         mock_hook.assert_not_called()
         z.step()
-        mock_hook.assert_called_once_with(z, ANY, ANY)
+        mock_hook.assert_has_calls(
+            [call(z, 0x8048B70, 2), call(z, 0x8048B72, 1)]
+        )
         mock_hook.reset_mock()
 
         z.delete_hook(hook_info)
@@ -222,7 +225,9 @@ class HookManagerTest(unittest.TestCase):
         )
         mock_hook.assert_not_called()
         z.step()
-        mock_hook.assert_called_once_with(z, ANY, ANY)
+        mock_hook.assert_has_calls(
+            [call(z, 0x8048B70, 2), call(z, 0x8048B72, 1)]
+        )
         mock_hook.reset_mock()
 
         z.internal_engine.processes.load_next_process()
@@ -231,7 +236,9 @@ class HookManagerTest(unittest.TestCase):
         )
         mock_hook.assert_not_called()
         z.step()
-        mock_hook.assert_called_once_with(z, ANY, ANY)
+        mock_hook.assert_has_calls(
+            [call(z, 0x8048B70, 2), call(z, 0x8048B72, 1)]
+        )
         mock_hook.reset_mock()
 
         z.delete_hook(hook_info)


### PR DESCRIPTION
We must make behavior between `start` and `step` to be as similar as possible. In this sense, we should not rely on unicorn's inbuilt `count` argument. This resulted in `step` being one instruction behind.

View comment in `step` function for more details.

We should also remove the count argument from start to ensure that users don't have unexpected behavior.