### PR TITLE
Create breakpoint manager class

### DIFF
--- a/src/zelos/breakpoints.py
+++ b/src/zelos/breakpoints.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2020 Zeropoint Dynamics
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+
+# You should have received a copy of the GNU Affero General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+# ======================================================================
+
+import logging
+
+from typing import Dict
+
+from zelos.hooks import HookType
+
+
+class Breakpoint:
+    """
+    Keeps track of information regarding a breakpoint.
+    """
+
+    def __init__(self, hook_info, is_temporary):
+        # Skips this breakpoint this number of times. Values <=0 mean
+        # the breakpoint is not skipped
+        self.skip_count = 0
+        # Read-only
+        self._is_temporary = is_temporary
+        self._hook_info = hook_info
+
+    @property
+    def is_temporary(self):
+        return self._is_temporary
+
+
+class BreakpointManager:
+    """
+    Manages the state of breakpoints in Zelos.
+    """
+
+    def __init__(self, hook_manager):
+        self.logger = logging.getLogger(__name__)
+
+        self._breakpoints: Dict[int, Breakpoint] = {}
+        self._hook_manager = hook_manager
+
+    def get_breakpoints(self) -> Dict[int, Breakpoint]:
+        """
+        Returns a dict of address -> Breakpoint
+        """
+        return self._breakpoints.copy()
+
+    def set_breakpoint(self, address: int, temporary: bool) -> None:
+        """
+        Sets a breakpoint at the given address if one does not already
+        exist there.
+        """
+        if address in self._breakpoints:
+            self.logger.notice(
+                f"Breakpoint already set for address {address:x}"
+            )
+            return
+
+        def hook(zelos, address, size):
+            b = self._breakpoints[address]
+            if b.skip_count > 0:
+                b.skip_count -= 1
+                return
+            zelos.stop("breakpoint")
+            if temporary:
+                self.remove_breakpoint(address)
+
+        hook_info = self._hook_manager.register_exec_hook(
+            HookType.EXEC.INST,
+            hook,
+            ip_low=address,
+            ip_high=address,
+            name=f"breakpoint_{address:x}",
+        )
+        bp = Breakpoint(hook_info, temporary)
+        self._breakpoints[address] = bp
+        self.logger.debug(f"Set breakpoint at {address:x}")
+
+    def remove_breakpoint(self, address: int) -> bool:
+        """
+        Removes a breakpoint if one exists at that address.
+        """
+        bp = self._breakpoints.get(address, None)
+        if bp is None:
+            self.logger.error(f"No breakpoint at {address:x} to remove")
+            return
+        self._hook_manager.delete_hook(bp._hook_info)
+        del self._breakpoints[address]
+
+    def _disable_breakpoints_on_start(self, address: int):
+        """
+        In order to get past breakpoints, we need to disable any
+        breakpoints that are at the starting address.
+        """
+        b = self._breakpoints.get(address, None)
+        if b is not None:
+            b.skip_count += 1

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -43,6 +43,7 @@ from capstone import (
 from unicorn import UcError
 
 from zelos import util
+from zelos.breakpoints import BreakpointManager
 from zelos.config_gen import _generate_without_binary, generate_config
 from zelos.exceptions import UnsupportedBinaryError, ZelosLoadException
 from zelos.file_system import FileSystem
@@ -115,6 +116,7 @@ class Engine:
         self.timer = util.Timer()
 
         self.hook_manager = HookManager(self, self.api)
+        self.breakpoints = BreakpointManager(self.hook_manager)
         self.interrupt_handler = InterruptHooks(self.hook_manager, self)
         self.exception_handler = ExceptionHooks(self)
         self.processes = Processes(
@@ -603,6 +605,7 @@ class Engine:
             t is not None
         ), "Current thread is None. Something has gone horribly wrong."
 
+        self.breakpoints._disable_breakpoints_on_start(t.getIP())
         if t.emu.is_running:
             self.logger.critical(
                 "Trying to run unicorn while unicorn is already running. "

--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -273,7 +273,7 @@ class HookManager:
         """
         if self.z.emu.is_running:
             closure = functools.partial(self.delete_hook, hook_info)
-            self._to_delete_closures.append(closure)
+            self._stop_to_delete_hook(closure)
             return
 
         if self._is_unicorn_hook(hook_info.type):
@@ -286,6 +286,10 @@ class HookManager:
                     f"Hook handle {hook_info.handle} does not exist for"
                     f"hook type {hook_info.type}"
                 )
+
+    def _stop_to_delete_hook(self, closure):
+        self._to_delete_closures.append(closure)
+        self.z.scheduler.stop_and_exec("delete hook", lambda: True)
 
     def _clear_deleted_hooks(self):
         """
@@ -308,7 +312,7 @@ class HookManager:
         """
         if self.z.emu.is_running:
             closure = functools.partial(self._delete_unicorn_hook, handle)
-            self._to_delete_closures.append(closure)
+            self._stop_to_delete_hook(closure)
             return
         for p in self.z.processes.process_list:
             p.hooks._delete_unicorn_hook(handle)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,18 +213,32 @@ class ZelosTest(unittest.TestCase):
 
     def test_breakpoint(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))
-        addr = 0x0816348F
+        addr = 0x8048B72
         z.set_breakpoint(addr)
         z.start()
 
         tm = z.internal_engine.thread_manager
         self.assertEqual(tm.num_active_threads(), 1)
-        self.assertEqual(z.regs.getIP(), addr)
+        self.assertEqual(
+            z.regs.getIP(), addr, f"{z.regs.getIP():x} vs. {addr:x}"
+        )
 
+        z.step()
+        self.assertEqual(
+            z.regs.getIP(), 0x8048B73, f"{z.regs.getIP():x} vs. {0x8048b73:x}"
+        )
+
+    def test_remove_breakpoint(self):
+        z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))
+        addr = 0x8048B72
+        z.set_breakpoint(addr)
         z.remove_breakpoint(addr)
+        z.set_breakpoint(0x8048B73)
         z.start()
 
-        self.assertEqual(1, len(tm.completed_threads))
+        self.assertEqual(
+            z.regs.getIP(), 0x8048B73, f"{z.regs.getIP():x} vs. {0x8048b73:x}"
+        )
 
     def test_syscall_breakpoint(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))


### PR DESCRIPTION
This merge also allows continuing/stepping from a permanent breakpoint. Previously, permanent breakpoints would cause execution to stop until the breakpoint was deleted. Now, breakpoints are temporarily disabled when starting execution.