### PR TITLE
Improvements to read syscall

### DIFF
--- a/src/zelos/ext/platforms/linux/syscalls/arg_strings.py
+++ b/src/zelos/ext/platforms/linux/syscalls/arg_strings.py
@@ -15,6 +15,8 @@
 # <http://www.gnu.org/licenses/>.
 # ======================================================================
 
+from zelos.enums import ProtType
+
 from ..signals import Signal, sigmask_string
 from .syscall_utils import twos_comp
 from .syscalls_const import (
@@ -101,6 +103,8 @@ def get_arg_string(z, arg):
             handle.category() if handle is not None else "unknown"
         )
         arg_string = f"{name}=0x{val:x} ({handle_category})"
+    elif type_str in ["int"] and name in ["prot"]:
+        arg_string = f"{name}={ProtType(val)._name_}"
     elif type_str in ["fd_set*"]:
         if val == 0:
             arg_string = f"{name}=0x{val:x} ()"

--- a/src/zelos/ext/platforms/linux/syscalls/syscall_structs.py
+++ b/src/zelos/ext/platforms/linux/syscalls/syscall_structs.py
@@ -141,3 +141,25 @@ class STAT64(ctypes.Structure):
         # ('__unused4', ctypes.c_uint32),
         # ('__unused5', ctypes.c_uint32),
     ]
+
+
+class STATFS(ctypes.Structure):
+    # This is intended for 64 bit architectures.
+    # https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/stat.h
+    _fields_ = [
+        ("f_type", ctypes.c_uint32),  # integer vector describing variable */
+        ("f_bsize", ctypes.c_uint32),  # length of this vector */
+        ("f_blocks", ctypes.c_uint32),
+        (
+            "f_bfree",
+            ctypes.c_uint32,
+        ),  # 0 or address where to store old value */
+        ("f_bavail", ctypes.c_uint32),
+        ("f_files", ctypes.c_uint32),
+        ("f_ffree", ctypes.c_uint32),
+        ("f_fsid", ctypes.c_uint32),
+        ("f_namelen", ctypes.c_uint32),
+        ("f_frsize", ctypes.c_int32),
+        ("f_flags", ctypes.c_uint32),
+        ("f_spare", ctypes.c_uint32),
+    ]

--- a/src/zelos/ext/platforms/linux/syscalls/syscall_utils.py
+++ b/src/zelos/ext/platforms/linux/syscalls/syscall_utils.py
@@ -80,8 +80,8 @@ def _get_msr(p, msr):
     orip = emu.get_reg("rip")
 
     # x86: rdmsr
-    buf = "\x0f\x32"
-    buf_ptr = memory.heap.alloc(2, "wrmsr inst")
+    buf = b"\x0f\x32"
+    buf_ptr = memory.map_anywhere(2, "rdmsr inst")
     memory.write(buf_ptr, buf)
 
     emu.set_reg("rcx", msr & 0xFFFFFFFF)

--- a/src/zelos/handles/base_handles.py
+++ b/src/zelos/handles/base_handles.py
@@ -78,12 +78,19 @@ class FileHandle(Handle):
     ):
         super().__init__(name, parent_thread, access)
         self._file_system = file_system
-        # Keep in mind that only files that are in the sandbox are writable.
-        self._file = file_system.open_library(name)
-        if self._file is None:
-            self._file = self._file_system.open_sandbox_file(name)
-
+        self._file = None
         self.is_dir = is_dir
+        if is_dir:
+            return
+        # Keep in mind that only files that are in the sandbox are writable.
+        try:
+            self._file = file_system.open_library(name)
+            if self._file is None:
+                self._file = self._file_system.open_sandbox_file(
+                    name, create_if_not_exists=True
+                )
+        except IsADirectoryError:
+            self.is_dir = True
 
     def seek(self, offset: int, whence: int = 0) -> None:
         if self._file is None:

--- a/src/zelos/memory.py
+++ b/src/zelos/memory.py
@@ -832,7 +832,17 @@ class Memory:
         del self.mem_hooks[addr]
         return mem_hook.hook(uc, access, address, size, value, user_data)
 
-    def get_region(self, address):
+    def is_writable(self, address: int) -> bool:
+        """
+        Returns True if writing memory is allowed at the specified
+        address.
+        """
+        for (begin, end, perms) in self.emu.mem_regions():
+            if begin <= address < end:
+                return perms & ProtType.WRITE
+        return False
+
+    def get_region(self, address: int) -> Optional[Section]:
         """ Gets the region that this address belongs to."""
         for section in self.memory_info.values():
             if section.address <= address < section.address + section.size:

--- a/tests/test_linux_mips.py
+++ b/tests/test_linux_mips.py
@@ -19,7 +19,7 @@ import unittest
 
 from os import path
 
-from zelos import HookType, Zelos
+from zelos import Zelos
 
 
 DATA_DIR = path.join(path.dirname(path.abspath(__file__)), "data")
@@ -28,7 +28,6 @@ DATA_DIR = path.join(path.dirname(path.abspath(__file__)), "data")
 class ZelosTest(unittest.TestCase):
     def test_static_elf_el(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_mipsel_mti_helloworld"))
-        z.internal_engine.set_hook_granularity(HookType.EXEC.BLOCK)
         z.internal_engine.start(timeout=10)
 
         self.assertEqual(
@@ -41,7 +40,6 @@ class ZelosTest(unittest.TestCase):
                 "Skipping `test_static_elf_eb`: Windows lief fails to parse"
             )
         z = Zelos(path.join(DATA_DIR, "static_elf_mipseb_mti_helloworld"))
-        z.internal_engine.set_hook_granularity(HookType.EXEC.BLOCK)
         z.internal_engine.start(timeout=10)
 
         self.assertEqual(

--- a/tests/test_ltp_syscalls.py
+++ b/tests/test_ltp_syscalls.py
@@ -129,7 +129,7 @@ class ZelosTest(unittest.TestCase):
     def test_read(self):
         buffer = self._ltp_run("ltp_x64/syscalls/read01")
         self.assertIn("passed   1", str(buffer))
-        # buffer = self._ltp_run('ltp_x64/syscalls/read02')
+        buffer = self._ltp_run("ltp_x64/syscalls/read02")
         # buffer = self._ltp_run('ltp_x64/syscalls/read03')
         buffer = self._ltp_run("ltp_x64/syscalls/read04")
 


### PR DESCRIPTION
Actually use memory permissions, give correct errors for read failures.
File handles can identify directories better
Statfs syscall actually writes partial statfs struct.