### PR TITLE
Limit the printing of syscalls after x reps

### DIFF
--- a/src/zelos/ext/plugins/trace.py
+++ b/src/zelos/ext/plugins/trace.py
@@ -185,7 +185,8 @@ class Trace(IPlugin):
 
     def traceoff_syscall(self, syscall_name):
         """
-        Disable verbose tracing after a specific system call has executed.
+        Disable verbose tracing after a specific system call has
+        executed.
         """
 
         def hook_traceoff(zelos, sysname, args, retval):
@@ -217,7 +218,8 @@ class Trace(IPlugin):
 
     def traceon_syscall(self, syscall_name):
         """
-        Enable verbose tracing after a specific system call has executed.
+        Enable verbose tracing after a specific system call has
+        executed.
         """
 
         def hook_traceon(zelos, sysname, args, retval):
@@ -270,7 +272,9 @@ class Trace(IPlugin):
                     self.ins(insn)
         except UcError as e:
             if e.errno == UC_ERR_READ_UNMAPPED:
-                print("Unable to read instruction at address %x" % address)
+                self.logger.error(
+                    f"Unable to read instruction at address {address:x}"
+                )
             else:
                 raise e
 

--- a/src/zelos/triggers.py
+++ b/src/zelos/triggers.py
@@ -20,6 +20,8 @@ import time
 from collections import defaultdict
 from enum import Enum
 
+from zelos.hooks import HookType
+
 
 class RuleType(Enum):
     NORMAL = 1
@@ -96,6 +98,14 @@ class Triggers:
         self.apis_called = defaultdict(list)
         self.api_strings = set()
         self.syscalls_called = defaultdict(list)
+
+        def syscall_hook(zelos, sysname, args, retval):
+            self.z.triggers.tr_call_syscall(sysname)
+            self.z.triggers.tr_syscall(zelos.thread, sysname, args, retval)
+
+        self.z.hook_manager.register_syscall_hook(
+            HookType.SYSCALL.AFTER, syscall_hook, name="triggers"
+        )
 
     def _update_msg(self):
         blocks = self.z.emu.bb_count()


### PR DESCRIPTION
Printing of them same syscall many times in a row often loses meaningfulness after a certain point. To speed up execution and clean up output, Zelos will now stop printing syscalls that repeat a certain number of times without another syscall in-between.