### PR TITLE
Ensure that deleted cross_process_hooks stay dead

### DIFF
--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -314,6 +314,7 @@ class HookManager:
             closure = functools.partial(self._delete_unicorn_hook, handle)
             self._stop_to_delete_hook(closure)
             return
+        del self._cross_process_hooks[handle]
         for p in self.z.processes.process_list:
             p.hooks._delete_unicorn_hook(handle)
 
@@ -400,7 +401,7 @@ class HookManager:
                     end_addr=end_addr,
                 )
 
-        self._cross_process_hooks[name] = HookInfo(
+        self._cross_process_hooks[handle] = HookInfo(
             hook_type,
             wrapped_callback,
             handle,
@@ -410,7 +411,7 @@ class HookManager:
             end_condition,
         )
 
-        return self._cross_process_hooks[name]
+        return self._cross_process_hooks[handle]
 
     def _get_hooks(self, hook_type):
         return self._hooks[hook_type].values()

--- a/tests/test_hook_manager.py
+++ b/tests/test_hook_manager.py
@@ -201,6 +201,17 @@ class HookManagerTest(unittest.TestCase):
         z.step()
         mock_hook.assert_not_called()
 
+        # Ensure that deleted hooks are not called even from new processes.
+        pid = z.internal_engine.processes.new_process("test_process_2")
+        p = z.internal_engine.processes.get_process(pid)
+        p.new_thread(start_addr)
+        p.memory.copy(z.internal_engine.memory)
+        z.internal_engine.processes.load_process(pid)
+
+        mock_hook.assert_not_called()
+        z.step()
+        mock_hook.assert_not_called()
+
     def test_cross_process_hooks_existing_process(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"))
 


### PR DESCRIPTION
* Eventually we should give the option to specify cross process or not.