### PR TITLE
Update code coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,12 @@ commands = python -m pytest -n auto --rootdir={envsitepackagesdir}/zelos {posarg
 [testenv:py37]
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
+basepython = python3.7
 install_command = pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
 extras = {env:TOX_AP_TEST_EXTRAS:tests}
-commands = coverage run --parallel -m pytest {posargs}
+commands = coverage run --parallel --source={envsitepackagesdir}/zelos -m pytest {posargs}
 
 
 [testenv:py38]
@@ -39,7 +40,7 @@ install_command = pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
 extras = {env:TOX_AP_TEST_EXTRAS:tests}
-commands = coverage run --parallel -m pytest {posargs}
+commands = python -m pytest -n auto --rootdir={envsitepackagesdir}/zelos {posargs}
 
 
 [testenv:coverage-report]


### PR DESCRIPTION
Updates to code coverage to include paths currently being ignored by coverage reports (e.g. `zelos\ext\plugins\**\*`)