### PR TITLE
Rename --strace to --trace_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ You can print only the first time each instruction is executed, rather than *eve
 $ zelos -v --fasttrace my_binary
 ```
 
-By default, syscalls are emitted on stdout. To write syscalls to a file instead, use the `--strace` flag:
+By default, syscalls are emitted on stdout. To write syscalls to a file instead, use the `--trace_file` flag:
 ```console
-$ zelos --strace path/to/file my_binary
+$ zelos --trace_file path/to/file my_binary
 ```
 
 Specify any command line arguments after the binary name:

--- a/docs/tutorials/01_cmdline.md
+++ b/docs/tutorials/01_cmdline.md
@@ -16,9 +16,9 @@ To print only the *first* time an instruction is executed, rather than *every* i
 $ zelos -v --fasttrace my_binary
 ```
 
-To write output to a file, instead of stdout, use the `--strace` flag:
+To write output to a file use the `--trace_file` flag:
 ```console
-$ zelos --strace /path/to/file my_binary
+$ zelos --trace_file /path/to/file my_binary
 ```
 
 To provide command line arguments to the emulated binary, specify them after the binary name:

--- a/src/zelos/config_gen.py
+++ b/src/zelos/config_gen.py
@@ -72,7 +72,6 @@ def _generate_without_binary(**kwargs):
 def generate_parser():
     parser = configargparse.ArgumentParser()
     group_logging = parser.add_argument_group("logging")
-    group_reporting = parser.add_argument_group("reporting")
     group_limits = parser.add_argument_group("limits")
     group_networking = parser.add_argument_group("networking")
     group_fs = parser.add_argument_group("filesystem")
@@ -179,12 +178,6 @@ def generate_parser():
         "--disableNX",
         action="store_true",
         help="Disable the no-execute bit. All memory becomes executable.",
-    )
-    group_reporting.add_argument(
-        "--strace",
-        type=str,
-        default=None,
-        help="Writes the system call trace to the specified output file.",
     )
     group_logging.add_argument(
         "--log_exports",

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -105,7 +105,7 @@ class Engine:
 
         self.timer = util.Timer()
 
-        self.zml_parser = ZmlParser(self)
+        self.zml_parser = ZmlParser(self.api)
         self.hook_manager = HookManager(self, self.api)
         self.breakpoints = BreakpointManager(self.hook_manager)
         self.interrupt_handler = InterruptHooks(self.hook_manager, self)
@@ -155,8 +155,6 @@ class Engine:
                     f"Incorrectly formatted input to '--mount': {m}"
                 )
                 continue
-        if config.strace is not None:
-            self.zos.syscall_manager.set_strace_file(config.strace)
 
     def __del__(self):
         try:

--- a/src/zelos/ext/plugins/trace.py
+++ b/src/zelos/ext/plugins/trace.py
@@ -22,7 +22,7 @@ import capstone.x86_const as cs_x86
 
 from termcolor import colored
 
-from zelos import HookType, IPlugin
+from zelos import CommandLineOption, HookType, IPlugin
 from zelos.exceptions import MemoryReadUnmapped
 
 
@@ -33,11 +33,20 @@ class Comment:
         self.text = text
 
 
+CommandLineOption(
+    "trace_file", type=str, default=None, help="Writes the trace to a file."
+)
+
+
 class Trace(IPlugin):
     def __init__(self, z):
         self.zelos = z
 
         self.logger = logging.getLogger(__name__)
+
+        self.trace_file = None
+        if z.config.trace_file is not None:
+            self.trace_file = open(z.config.trace_file, "w")
 
         self.current_return_address = 0
         self.current_function_name = "???"
@@ -93,14 +102,6 @@ class Trace(IPlugin):
     @property
     def functions_called(self):
         return self.comment_generator.functions_called
-
-    @property
-    def strace_file(self):
-        return self.zelos.internal_engine.zos.syscall_manager.strace_file
-
-    @property
-    def strace(self):
-        return self.zelos.config.strace
 
     def set_hook_granularity(self, granularity: HookType.EXEC):
         """
@@ -315,13 +316,13 @@ class Trace(IPlugin):
         if addr_str is None:
             addr_str = f"{self.zelos.regs.getIP():08x}"
 
-        if self.strace:
+        if self.trace_file is not None:
             thread_str = f"[{thread}]"
             category_str = f"[{category}]"
             addr_str_str = f"[{addr_str}]"
             print(
                 f"{thread_str} {category_str} {addr_str_str} {s}",
-                file=self.strace_file,
+                file=self.trace_file,
             )
         else:
             thread_str = colored(f"[{thread}]", "magenta")
@@ -379,7 +380,7 @@ class Trace(IPlugin):
         if indent_count == -1:
             indent_count = 0
         args = "".join([i if ord(i) < 128 else "." for i in args])
-        if self.strace:
+        if self.trace_file is not None:
             s = "  " * min(indent_count, self.MAX_INDENTS) + args
         else:
             s = "  " * min(indent_count, self.MAX_INDENTS) + colored(
@@ -398,7 +399,7 @@ class Trace(IPlugin):
         ins_string = self._get_insn_string(insn)
         if address in self.zelos.main_binary.exported_functions:
             function_name = self.zelos.main_binary.exported_functions[address]
-            if self.strace:
+            if self.trace_file is not None:
                 s = f"<{function_name}>"
             else:
                 s = colored(f"<{function_name}>", "white", attrs=["bold"])
@@ -444,7 +445,7 @@ class Trace(IPlugin):
                 padSize = 1
             for y in range(0, padSize):
                 padding += " "
-            if self.strace:
+            if self.trace_file is not None:
                 result += insn_str + " " + padding + " ; " + cmt
             else:
                 result += (

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -83,4 +83,4 @@ class OverlayTest(unittest.TestCase):
         data = output.read()[len("DISAS\n") :]
         memdump = json.loads(data)
 
-        self.assertEqual(len(memdump["functions"]), 239)
+        self.assertEqual(len(memdump["functions"]), 244)

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -18,6 +18,8 @@
 
 from __future__ import absolute_import
 
+import os
+import tempfile
 import unittest
 
 from io import StringIO
@@ -65,6 +67,23 @@ class TraceTest(unittest.TestCase):
             z.start()
             # self.assertIn("[0815b56f]", stdout.getvalue())
             self.assertNotIn("[0815b575]", stdout.getvalue())
+
+    def test_trace_file_cmdline_option(self):
+        fd, temp_file = tempfile.mkstemp()
+
+        z = Zelos(
+            path.join(DATA_DIR, "static_elf_helloworld"), trace_file=temp_file
+        )
+
+        z.start()
+
+        f = open(temp_file, "r")
+        self.assertEqual(len(f.readlines()), 12)
+
+        f.close()
+        z.plugins.trace.trace_file.close()
+        os.close(fd)
+        os.remove(temp_file)
 
     def test_x86_comments(self):
         z = Zelos(path.join(DATA_DIR, "static_elf_helloworld"), verbosity=1)


### PR DESCRIPTION
This file will eventually contain any output from the trace plugin, which may include more than just syscalls.