### PR TITLE
Add target_binary_path to Api

### DIFF
--- a/src/zelos/__init__.py
+++ b/src/zelos/__init__.py
@@ -14,7 +14,7 @@
 # License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 # ======================================================================
-__version__ = "0.0.2.dev0"
+__version__ = "0.1.1.dev0"
 
 __title__ = "zelos"
 __description__ = "A comprehensive binary emulation platform."

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -639,10 +639,11 @@ class Zelos:
         Returns the parsed main binary, if it exists, otherwise returns None.
         Note that the "main" binary denotes the binary that is loaded by
         Zelos during emulation, not necessarily the binary that
-        is specified as input. When the specified input binary is statically
-        linked, it is also the main binary. However, when the specified
-        input binary is dynamically linked, the "main" binary instead refers
-        to the dynamic linker/loader.
+        is specified as input (the "target" binary). When the specified
+        input binary ("target") is statically linked, it is also the "main"
+        binary. However, when the specified input binary ("target") is
+        dynamically linked, the "main" binary instead refers to the dynamic
+        linker/loader.
 
         :type: :py:class:`zelos.plugin.ParsedBinary`
 
@@ -656,10 +657,11 @@ class Zelos:
         returns None.
         Note that the "main" binary denotes the binary that is loaded by
         Zelos during emulation, not necessarily the binary that
-        is specified as input. When the specified input binary is statically
-        linked, it is also the main binary. However, when the specified
-        input binary is dynamically linked, the "main" binary instead refers
-        to the dynamic linker/loader.
+        is specified as input (the "target" binary). When the specified
+        input binary ("target") is statically linked, it is also the "main"
+        binary. However, when the specified input binary ("target") is
+        dynamically linked, the "main" binary instead refers to the dynamic
+        linker/loader.
 
         :type: str
 

--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -637,6 +637,12 @@ class Zelos:
     def main_binary(self) -> Optional[ParsedBinary]:
         """
         Returns the parsed main binary, if it exists, otherwise returns None.
+        Note that the "main" binary denotes the binary that is loaded by
+        Zelos during emulation, not necessarily the binary that
+        is specified as input. When the specified input binary is statically
+        linked, it is also the main binary. However, when the specified
+        input binary is dynamically linked, the "main" binary instead refers
+        to the dynamic linker/loader.
 
         :type: :py:class:`zelos.plugin.ParsedBinary`
 
@@ -648,12 +654,32 @@ class Zelos:
         """
         Returns the absolute path to the main binary, if it exists, otherwise
         returns None.
+        Note that the "main" binary denotes the binary that is loaded by
+        Zelos during emulation, not necessarily the binary that
+        is specified as input. When the specified input binary is statically
+        linked, it is also the main binary. However, when the specified
+        input binary is dynamically linked, the "main" binary instead refers
+        to the dynamic linker/loader.
 
         :type: str
 
         """
         if self.internal_engine.main_module_name:
             return abspath(self.internal_engine.main_module_name)
+        return None
+
+    @property
+    def target_binary_path(self) -> Optional[str]:
+        """
+        Returns the absolute path to the target binary, if it exists, otherwise
+        returns None. Note that the "target" binary denotes the binary
+        specified as input to Zelos.
+
+        :type: str
+
+        """
+        if self.internal_engine.target_binary_path:
+            return abspath(self.internal_engine.target_binary_path)
         return None
 
 

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -102,6 +102,7 @@ class Engine:
         # If verbose is true, print lots of info, including every
         # instruction
         self.original_file_name = ""
+        self.target_binary_path = ""
         self.main_module_name = ""
         self.main_module = None
 
@@ -332,6 +333,8 @@ class Engine:
         This method simply loads the executable, without starting the
         emulation
         """
+
+        self.target_binary_path = module_path
 
         original_file_name = os.path.basename(module_path)
         self.original_file_name = original_file_name

--- a/src/zelos/tools/zdbserver/zdbserver.py
+++ b/src/zelos/tools/zdbserver/zdbserver.py
@@ -293,7 +293,7 @@ class ZdbServer:
         Returns:
             The full path to the emulated binary.
         """
-        return self.z.main_binary_path
+        return self.z.target_binary_path
 
 
 def create_server(cmdline_options: str) -> SimpleXMLRPCServer:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -308,7 +308,7 @@ class ZelosTest(unittest.TestCase):
         self.assertIsNotNone(reg)
         self.assertEqual(len(z.memory.get_regions()), 4)
 
-    def test_main_binary(self):
+    def test_binary_paths(self):
         z = Zelos(None)
         self.assertIsNone(z.main_binary)
         self.assertIsNone(z.main_binary_path)
@@ -317,6 +317,18 @@ class ZelosTest(unittest.TestCase):
         self.assertIsNotNone(z.main_binary)
         self.assertEqual(
             path.basename(z.main_binary_path), "static_elf_helloworld"
+        )
+        self.assertEqual(
+            path.basename(z.target_binary_path), "static_elf_helloworld"
+        )
+
+        z = Zelos(path.join(DATA_DIR, "dynamic_elf_helloworld"))
+        self.assertIsNotNone(z.main_binary)
+        self.assertNotEqual(
+            path.basename(z.main_binary_path), "dynamic_elf_helloworld"
+        )
+        self.assertEqual(
+            path.basename(z.target_binary_path), "dynamic_elf_helloworld"
         )
 
     def test_memory_api_pack(self):


### PR DESCRIPTION
`target_binary_path` always returns the paths of the binary specified as input to Zelos. This differs from `main_binary_path` which refers to the dynamic linker/loader in the case where the binary specified as input is dynamically linked.