### PR TITLE
3rd-party plugin support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ not_skip="__init__.py"
 use_parentheses=true
 
 known_first_party="zelos"
-known_third_party=["capstone", "colorama", "configargparse", "dnslib", "filelock", "hypothesis", "idaapi", "idc", "lark", "lief", "mock", "pypacker", "pytest", "recommonmark", "setuptools", "sortedcontainers", "sphinx_rtd_theme", "termcolor", "unicorn", "verboselogs", "zelos"]
+known_third_party=["capstone", "colorama", "configargparse", "dnslib", "filelock", "hypothesis", "idaapi", "idc", "lark", "lief", "mock", "pkg_resources", "pypacker", "pytest", "recommonmark", "setuptools", "sortedcontainers", "sphinx_rtd_theme", "termcolor", "unicorn", "verboselogs", "zelos"]
 
 [tool.pytest]
 junit_family = "xunit2"

--- a/src/zelos/plugin/plugin.py
+++ b/src/zelos/plugin/plugin.py
@@ -23,6 +23,8 @@ from collections import defaultdict
 from os.path import isabs
 from typing import Callable
 
+import pkg_resources
+
 import zelos.ext.platforms
 import zelos.ext.plugins
 
@@ -51,6 +53,12 @@ plugins_loaded = set()
 def load(paths):
     """Loads the plugins that are located in the plugins directory."""
     global plugins_loaded
+
+    # Load plugins/commands exported via `entry_point`
+    [
+        entry_point.load()
+        for entry_point in pkg_resources.iter_entry_points("zelos.plugins")
+    ]
 
     # Load plugins that come with zelos
     paths += zelos.ext.plugins.__path__._path


### PR DESCRIPTION
Support for `pip install` 3rd-party plugins.

Any python package can export an `entry_points` in setup.py

example setup.py:

```python
    from setuptools import setup

    setup(
        name="zelos_minimal_plugin",
        entry_points={"zelos.plugins": ["zelos_minimal_plugin=zelos_minimal_plugin",],},
    )
```

If a package exports this, and contains IPlugins or CommandLineOptions, it will be loaded as a plugin in zelos without specifying it's directory.