### PR TITLE
Handle linux socket BlockingIOError on recvfrom

### DIFF
--- a/src/zelos/ext/platforms/linux/syscalls/syscalls_socket.py
+++ b/src/zelos/ext/platforms/linux/syscalls/syscalls_socket.py
@@ -457,7 +457,7 @@ def recvfrom(sm, p, args_addr):
         if len(data) > 0:
             p.memory.write(args.buf, data)
         return len(data)
-    except BlockingIOError e:
+    except BlockingIOError as e:
         sm.set_errno(e.errno)
         return -e.errno
     except Exception as e:


### PR DESCRIPTION
Python's built-in exception BlockingIOError corresponds to
errno EAGAIN, EALREADY, EWOULDBLOCK, and EINPROGRESS. These
cases need to be handled separately to ensure the syscall
does not fail due to blocking of a non-blocking operation.