### PR TITLE
Stop before you add a unicorn hook.

### DIFF
--- a/src/zelos/emulator/base.py
+++ b/src/zelos/emulator/base.py
@@ -464,9 +464,11 @@ class IEmuHelper:
     def hook_add(
         self, htype, callback, user_data=None, begin=1, end=0, arg1=0
     ):
+        assert not self.is_running
         return self._uc.hook_add(htype, callback, user_data, begin, end, arg1)
 
     def hook_del(self, h):
+        assert not self.is_running
         return self._uc.hook_del(h)
 
     def mem_map(

--- a/src/zelos/processes.py
+++ b/src/zelos/processes.py
@@ -88,7 +88,7 @@ class Process:
         self.threads = Threads(
             self.emu, self.memory, self.processes.stack_size
         )
-        self.hooks = Hooks(self.emu, self.threads)
+        self.hooks = Hooks(self.emu, self.threads, self.threads.scheduler)
 
     def __str__(self) -> str:
         return f"Name: '{self.name}', pid: {self.pid:x}, "


### PR DESCRIPTION
For some reason, if we add hooks within other hooks in unicorn, we get unexpected results. To overcome this, we will always stop when adding hooks.

Assertions to ensure that this is the case at the emulator level. 