### PR TITLE
Add hooking Zelos reads and writes

### DIFF
--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -81,6 +81,9 @@ class Zelos:
         self.internal_engine = e  # Used to inform what type this is.
         self.internal_engine.plugins = self.plugins
 
+        # After setup allow MEMORY.ZELOS_* hooks to run.
+        e.hook_manager._enable_zelos_memory_hooks()
+
     # **** Memory API ****
     @property
     def memory(self):
@@ -657,14 +660,15 @@ class Zelos:
     @property
     def main_binary(self) -> Optional[ParsedBinary]:
         """
-        Returns the parsed main binary, if it exists, otherwise returns None.
+        Returns the parsed main binary, if it exists, otherwise returns
+        None.
         Note that the "main" binary denotes the binary that is loaded by
         Zelos during emulation, not necessarily the binary that
         is specified as input (the "target" binary). When the specified
-        input binary ("target") is statically linked, it is also the "main"
-        binary. However, when the specified input binary ("target") is
-        dynamically linked, the "main" binary instead refers to the dynamic
-        linker/loader.
+        input binary ("target") is statically linked, it is also the
+        "main" binary. However, when the specified input binary
+        ("target") is dynamically linked, the "main" binary instead
+        refers to the dynamic linker/loader.
 
         :type: :py:class:`zelos.plugin.ParsedBinary`
 
@@ -694,9 +698,9 @@ class Zelos:
     @property
     def target_binary_path(self) -> Optional[str]:
         """
-        Returns the absolute path to the target binary, if it exists, otherwise
-        returns None. Note that the "target" binary denotes the binary
-        specified as input to Zelos.
+        Returns the absolute path to the target binary, if it exists,
+        otherwise returns None. Note that the "target" binary denotes
+        the binary specified as input to Zelos.
 
         :type: str
 

--- a/src/zelos/enums.py
+++ b/src/zelos/enums.py
@@ -25,6 +25,11 @@ class HookType:
         Used by :py:meth:`zelos.Zelos.hook_memory` to specify the
         memory event to hook on. View the registration function for more
         details.
+
+        ZELOS_READ|ZELOS_WRITE hook reads and writes that are done by
+        Zelos (such as those done within syscall implementations). Other
+        read and writes only hook memory accesses done by instructions
+        executed in the underlying emulator.
         """
 
         READ = auto()
@@ -40,6 +45,9 @@ class HookType:
         WRITE_INVALID = auto()
         INVALID = auto()
         VALID = auto()
+
+        ZELOS_READ = auto()
+        ZELOS_WRITE = auto()
 
     class EXEC(Enum):
         """

--- a/src/zelos/processes.py
+++ b/src/zelos/processes.py
@@ -83,7 +83,9 @@ class Process:
 
         self.modules = Modules()
 
-        self.memory = Memory(self.emu, processes.state, disableNX=disableNX)
+        self.memory = Memory(
+            self.emu, hook_manager, processes.state, disableNX=disableNX
+        )
 
         self.threads = Threads(
             self.emu, self.memory, self.processes.stack_size, hook_manager

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -30,7 +30,12 @@ from zelos.state import State
 class MemoryTest(unittest.TestCase):
     def test_memory_manager_map_anywhere(self):
         state = State(None, None, None)
-        mm = Memory(create_emulator(UC_ARCH_X86, UC_MODE_32, state), state)
+        hook_manager = None
+        mm = Memory(
+            create_emulator(UC_ARCH_X86, UC_MODE_32, state),
+            hook_manager,
+            state,
+        )
         address1 = mm.map_anywhere(0x1000, name="name1", kind="size1")
 
         self.assertEqual(mm.get_region(address1).name, "name1")
@@ -47,7 +52,13 @@ class MemoryTest(unittest.TestCase):
     def test_map_anywhere_bounded(self):
         # Check mapping when given bounds
         state = State(None, None, None)
-        mm = Memory(create_emulator(UC_ARCH_X86, UC_MODE_32, state), state)
+        hook_manager = None
+
+        mm = Memory(
+            create_emulator(UC_ARCH_X86, UC_MODE_32, state),
+            hook_manager,
+            state,
+        )
         min_addr = 0x10000
         max_addr = 0x12000
         address1 = mm.map_anywhere(
@@ -64,7 +75,12 @@ class MemoryTest(unittest.TestCase):
 
     def test_map_anywhere_bounded_preexisting_sections(self):
         state = State(None, None, None)
-        mm = Memory(create_emulator(UC_ARCH_X86, UC_MODE_32, state), state)
+        hook_manager = None
+        mm = Memory(
+            create_emulator(UC_ARCH_X86, UC_MODE_32, state),
+            hook_manager,
+            state,
+        )
         mm.map(0x10000, 0x1000)
         mm.map(0x15000, 0x1000)
         min_addr = 0x12000


### PR DESCRIPTION
There are times we need to understand what memory is being read and written by Zelos. The main example of this is in syscall implementations. ZELOS_READ and ZELOS_WRITE are hooks that allow hooking on zelos level reads and writes, rather than reads and writes caused by executing instructions.