### PR TITLE
Rename MEMORY.ZELOS_* hooks to MEMORY.INTERNAL_* hooks

### DIFF
--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -81,8 +81,8 @@ class Zelos:
         self.internal_engine = e  # Used to inform what type this is.
         self.internal_engine.plugins = self.plugins
 
-        # After setup allow MEMORY.ZELOS_* hooks to run.
-        e.hook_manager._enable_zelos_memory_hooks()
+        # After setup allow MEMORY.INTERNAL_* hooks to run.
+        e.hook_manager._enable_internal_memory_hooks()
 
     # **** Memory API ****
     @property

--- a/src/zelos/enums.py
+++ b/src/zelos/enums.py
@@ -26,7 +26,7 @@ class HookType:
         memory event to hook on. View the registration function for more
         details.
 
-        ZELOS_READ|ZELOS_WRITE hook reads and writes that are done by
+        INTERNAL_READ|INTERNAL_WRITE hook reads and writes that are done by
         Zelos (such as those done within syscall implementations). Other
         read and writes only hook memory accesses done by instructions
         executed in the underlying emulator.
@@ -46,8 +46,8 @@ class HookType:
         INVALID = auto()
         VALID = auto()
 
-        ZELOS_READ = auto()
-        ZELOS_WRITE = auto()
+        INTERNAL_READ = auto()
+        INTERNAL_WRITE = auto()
 
     class EXEC(Enum):
         """

--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -105,7 +105,7 @@ class HookManager:
         # are done by Zelos. However, memory initialization is not
         # interesting in that sense. We only turn on kernel_hooks after
         # initialization has been completed.
-        self._zelos_mem_hooks_enabled = False
+        self._internal_mem_hooks_enabled = False
 
     def register_mem_hook(
         self,
@@ -148,8 +148,8 @@ class HookManager:
         """
 
         if hook_type in [
-            HookType.MEMORY.ZELOS_READ,
-            HookType.MEMORY.ZELOS_WRITE,
+            HookType.MEMORY.INTERNAL_READ,
+            HookType.MEMORY.INTERNAL_WRITE,
         ]:
             return self._register_zelos_mem_hook(
                 hook_type, callback, mem_low, mem_high, name, end_condition
@@ -375,8 +375,8 @@ class HookManager:
     def _is_unicorn_hook(self, hook_type):
         if isinstance(hook_type, HookType.MEMORY):
             if hook_type in [
-                HookType.MEMORY.ZELOS_READ,
-                HookType.MEMORY.ZELOS_WRITE,
+                HookType.MEMORY.INTERNAL_READ,
+                HookType.MEMORY.INTERNAL_WRITE,
             ]:
                 return False
             return True
@@ -479,16 +479,16 @@ class HookManager:
     def _get_hooks(self, hook_type):
         if (
             hook_type
-            in [HookType.MEMORY.ZELOS_READ, HookType.MEMORY.ZELOS_WRITE]
-            and not self._zelos_mem_hooks_enabled
+            in [HookType.MEMORY.INTERNAL_READ, HookType.MEMORY.INTERNAL_WRITE]
+            and not self._internal_mem_hooks_enabled
         ):
             return []
         # Hooks might delete themselves, can't iterate over the values
         # if they are editing the underlying dictionary.
         return list(self._hooks[hook_type].values())
 
-    def _enable_zelos_memory_hooks(self):
-        self._zelos_mem_hooks_enabled = True
+    def _enable_internal_memory_hooks(self):
+        self._internal_mem_hooks_enabled = True
 
 
 class Hooks:

--- a/src/zelos/memory.py
+++ b/src/zelos/memory.py
@@ -123,7 +123,7 @@ class Memory:
             Bytes corresponding to data held in memory.
         """
         val = self.emu.mem_read(addr, size)
-        hooks = self._hook_manager._get_hooks(HookType.MEMORY.ZELOS_READ)
+        hooks = self._hook_manager._get_hooks(HookType.MEMORY.INTERNAL_READ)
         for hook in hooks:
             hook(0, addr, size, val)
         return val
@@ -140,7 +140,7 @@ class Memory:
             Number of bytes written.
         """
         self.emu.mem_write(addr, data)
-        hooks = self._hook_manager._get_hooks(HookType.MEMORY.ZELOS_WRITE)
+        hooks = self._hook_manager._get_hooks(HookType.MEMORY.INTERNAL_WRITE)
         for hook in hooks:
             hook(0, addr, len(data), data)
         return len(data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,13 +89,13 @@ class ZelosTest(unittest.TestCase):
             def __init__(self, z):
                 super().__init__(z)
                 z.hook_memory(
-                    HookType.MEMORY.ZELOS_READ,
+                    HookType.MEMORY.INTERNAL_READ,
                     zelos_read_hook,
                     name="test_zelos_read",
                     end_condition=lambda: True,
                 )
                 z.hook_memory(
-                    HookType.MEMORY.ZELOS_WRITE,
+                    HookType.MEMORY.INTERNAL_WRITE,
                     zelos_write_hook,
                     mem_low=0x08109A00,
                     mem_high=0x08109B00,


### PR DESCRIPTION
Whoops, meant to push this in the previous one.