### PR TITLE
Rename syscall manager to kernel

### DIFF
--- a/src/zelos/api/zelos_api.py
+++ b/src/zelos/api/zelos_api.py
@@ -486,7 +486,7 @@ class Zelos:
                 z.start()
 
         """
-        self.internal_engine.zos.syscall_manager.set_breakpoint(syscall_name)
+        self.internal_engine.kernel.set_breakpoint(syscall_name)
 
     def remove_syscall_breakpoint(self, syscall_name: str):
         """
@@ -509,9 +509,7 @@ class Zelos:
                 z.start()
 
         """
-        self.internal_engine.zos.syscall_manager.remove_breakpoint(
-            syscall_name
-        )
+        self.internal_engine.kernel.remove_breakpoint(syscall_name)
 
     def set_watchpoint(
         self, address: int, read: bool, write: bool, temporary: bool = False

--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -69,14 +69,6 @@ class Engine:
         if isinstance(config, str):
             config = generate_config(config)
         self.config = config
-        # OS plugins place OS-specific, system-wide, functionality
-        # in engine.zos
-
-        class ZOS(object):
-            def __init__(self):
-                pass
-
-        self.zos = ZOS()
 
         binary = config.filename
 
@@ -550,7 +542,7 @@ class Engine:
                     break
                 self.processes.swap_with_next_thread()
 
-        return self.zos.syscall_manager.generate_break_state()
+        return self.kernel.generate_break_state()
 
     def _run(self, p):
         t = p.current_thread

--- a/src/zelos/ext/platforms/linux/linux.py
+++ b/src/zelos/ext/platforms/linux/linux.py
@@ -27,10 +27,10 @@ from zelos import CommandLineOption
 from zelos.hooks import HookType
 from zelos.plugin import OSPlugin
 
+from .kernel import construct_kernel
 from .loader import ElfLoader, LinuxMode
 from .parse import LiefELF
 from .signals import Signals
-from .syscall_manager import construct_syscall_manager
 
 
 CommandLineOption(
@@ -112,7 +112,7 @@ class Linux(OSPlugin):
         )
 
     def _first_parse_setup(self, arch):
-        self.z.zos.syscall_manager = construct_syscall_manager(arch, self.z)
+        self.z.kernel = construct_kernel(arch, self.z)
 
         # On first parse, register process & thread creation hooks
         LinuxMode(arch, self.z)

--- a/src/zelos/ext/platforms/linux/loader.py
+++ b/src/zelos/ext/platforms/linux/loader.py
@@ -70,10 +70,10 @@ class LinuxMode:
 
         if self.z.state.arch == "arm":
             arm_private_syscall = {
-                0xFFFF0F60: self.z.zos.syscall_manager._kuser_cmpxchg64,
-                0xFFFF0FA0: self.z.zos.syscall_manager._kuser_memory_barrier,
-                0xFFFF0FC0: self.z.zos.syscall_manager._kuser_cmpxchg,
-                0xFFFF0FE0: self.z.zos.syscall_manager._kuser_get_tls,
+                0xFFFF0F60: self.z.kernel._kuser_cmpxchg64,
+                0xFFFF0FA0: self.z.kernel._kuser_memory_barrier,
+                0xFFFF0FC0: self.z.kernel._kuser_cmpxchg,
+                0xFFFF0FE0: self.z.kernel._kuser_get_tls,
             }.get(p.current_thread.getIP(), None)
             if arm_private_syscall is not None:
                 arm_private_syscall()
@@ -87,9 +87,7 @@ class LinuxMode:
         self.z.processes.handles.close_all(self.z.current_process.pid)
 
     def _attempt_to_handle_syscall(self):
-        syscall_action = self.z.zos.syscall_manager.handle_syscall(
-            self.z.current_process
-        )
+        syscall_action = self.z.kernel.handle_syscall(self.z.current_process)
         was_handled = syscall_action is not None
         return was_handled
 

--- a/src/zelos/ext/plugins/syscall_limiter.py
+++ b/src/zelos/ext/plugins/syscall_limiter.py
@@ -109,14 +109,14 @@ class SyscallLimiter(IPlugin):
             and self.rep_syscall_print_limit > 0
         ):
             rep_print_limit = self.rep_syscall_print_limit
-            syscall_manager = zelos.internal_engine.zos.syscall_manager
+            kernel = zelos.internal_engine.kernel
             if sysname == self._last_syscall:
                 self._last_syscall_count += 1
             else:
                 self._last_syscall = sysname
                 if self._last_syscall_count > rep_print_limit:
                     self.logger.info(f"Syscall printing reenabled")
-                    syscall_manager.should_print_syscalls = True
+                    kernel.should_print_syscalls = True
                 self._last_syscall_count = 1
 
             if self._last_syscall_count == rep_print_limit:
@@ -124,4 +124,4 @@ class SyscallLimiter(IPlugin):
                     f"Syscall {self._last_syscall} called over "
                     f"{rep_print_limit} times. No longer printing syscalls"
                 )
-                syscall_manager.should_print_syscalls = False
+                kernel.should_print_syscalls = False

--- a/src/zelos/ext/plugins/trace.py
+++ b/src/zelos/ext/plugins/trace.py
@@ -441,12 +441,12 @@ class ArmCommentGenerator:
         """
         Returns the syscall name
         """
-        sm = self.zelos.internal_engine.zos.syscall_manager
+        k = self.zelos.internal_engine.kernel
         if insn.insn_name() == "svc" and insn.operands[0].imm != 0:
             syscall_num = insn.operands[0].imm - 0x900000
         else:
-            syscall_num = sm.get_syscall_number()
-        syscall_name = sm.find_syscall_name_by_number(syscall_num)
+            syscall_num = k.get_syscall_number()
+        syscall_name = k.find_syscall_name_by_number(syscall_num)
         return f"{syscall_name}"
 
     def _dst_comment(self, insn):

--- a/src/zelos/plugin/__init__.py
+++ b/src/zelos/plugin/__init__.py
@@ -16,6 +16,7 @@
 # ======================================================================
 
 from .arg_base import ArgFactory
+from .kernel_base import IKernel
 from .loader_base import Loader
 from .parser_base import ParsedBinary, Section
 from .plugin import (
@@ -27,7 +28,6 @@ from .plugin import (
     PluginCommands,
     Plugins,
 )
-from .syscall_manager_base import SyscallManager
 
 
 __all__ = [
@@ -38,7 +38,7 @@ __all__ = [
     "OSPlugins",
     "ISubcommand",
     "PluginCommands",
-    "SyscallManager",
+    "IKernel",
     "Loader",
     "ParsedBinary",
     "Section",

--- a/src/zelos/plugin/kernel_base.py
+++ b/src/zelos/plugin/kernel_base.py
@@ -59,7 +59,7 @@ def str2struct(struct_obj, data):
     ctypes.memmove(ctypes.addressof(struct_obj), data, fit)
 
 
-class SyscallManager(object):
+class IKernel(object):
     def __init__(self, engine):
         self.logger = logging.getLogger(__name__)
         self.z = engine
@@ -230,8 +230,8 @@ class SyscallManager(object):
         for sys_name, overrides in override_dict.items():
             sys_func = self._name2syscall_func[sys_name]
 
-            def sys_func_wrapper(sm, p):
-                retval = sys_func(sm, p)
+            def sys_func_wrapper(k, p):
+                retval = sys_func(k, p)
                 if len(overrides) > 0:
                     self.logger.info("Invoking sysfunc return override")
                     return overrides.pop(0)
@@ -283,7 +283,7 @@ class SyscallManager(object):
     def return_addr(self):
         raise NotImplementedError()
 
-    def nullsub(self, sm, p):
+    def nullsub(self, k, p):
         return
 
     def fixme(self, msg):

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -19,19 +19,19 @@ import unittest
 from unittest.mock import Mock
 
 from zelos import Zelos
-from zelos.ext.platforms.linux.syscall_manager import X86SyscallManager
+from zelos.ext.platforms.linux.kernel import X86Kernel
 
 
-class SyscallManagerTest(unittest.TestCase):
+class KernelTest(unittest.TestCase):
     def test_syscall_override(self):
         z = Zelos(None)
-        sm = X86SyscallManager(z.internal_engine)
-        sm.register_overrides({"getuid": [1, 2]})
-        sys_func = sm._name2syscall_func["getuid"]
+        k = X86Kernel(z.internal_engine)
+        k.register_overrides({"getuid": [1, 2]})
+        sys_func = k._name2syscall_func["getuid"]
         p = Mock()
-        self.assertEqual(1, sys_func(sm, p))
-        self.assertEqual(2, sys_func(sm, p))
-        sys_func(sm, p)
+        self.assertEqual(1, sys_func(k, p))
+        self.assertEqual(2, sys_func(k, p))
+        sys_func(k, p)
 
 
 def main():

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -72,10 +72,8 @@ class ProcessesTest(unittest.TestCase):
         p1 = z.process
 
         # Make handle_syscall call fork
-        z.internal_engine.zos.syscall_manager.find_syscall_name_by_number = (
-            lambda x: "fork"
-        )
-        z.internal_engine.zos.syscall_manager.handle_syscall(p1)
+        z.internal_engine.kernel.find_syscall_name_by_number = lambda x: "fork"
+        z.internal_engine.kernel.handle_syscall(p1)
 
         new_pid = p1.emu.get_reg("eax")
         p2 = z.internal_engine.processes.get_process(new_pid)


### PR DESCRIPTION
This will replace the ZOS object which was intended to serve this purpose. 
The kernel will be a required object (much like the syscall manager) which will handle operating system details (such as syscalls).
