### PR TITLE
Add internal map hook

### DIFF
--- a/src/zelos/enums.py
+++ b/src/zelos/enums.py
@@ -23,13 +23,19 @@ class HookType:
     class MEMORY(Enum):
         """
         Used by :py:meth:`zelos.Zelos.hook_memory` to specify the
-        memory event to hook on. View the registration function for more
-        details.
+        memory event to hook on. View the registration function for
+        more details.
 
-        INTERNAL_READ|INTERNAL_WRITE hook reads and writes that are done by
-        Zelos (such as those done within syscall implementations). Other
-        read and writes only hook memory accesses done by instructions
-        executed in the underlying emulator.
+        INTERNAL_READ|INTERNAL_WRITE|INTERNAL_MAP are for hooking
+        reads|writes|maps that are done by Zelos (such as those done
+        within syscall implementations). Other read and writes only
+        hook memory accesses done by instructions executed in the
+        underlying emulator.
+
+        The callback for INTERNAL_MAP does not provide the data for the
+        mapping in the callback. This is because we didn't find an
+        efficient way to do so, causing a drastic slowdown for hooks
+        that didn't need the actual mapped data.
         """
 
         READ = auto()
@@ -48,6 +54,7 @@ class HookType:
 
         INTERNAL_READ = auto()
         INTERNAL_WRITE = auto()
+        INTERNAL_MAP = auto()
 
     class EXEC(Enum):
         """

--- a/src/zelos/hooks.py
+++ b/src/zelos/hooks.py
@@ -147,10 +147,7 @@ class HookManager:
 
         """
 
-        if hook_type in [
-            HookType.MEMORY.INTERNAL_READ,
-            HookType.MEMORY.INTERNAL_WRITE,
-        ]:
+        if self.is_internal_mem_hook(hook_type):
             return self._register_zelos_mem_hook(
                 hook_type, callback, mem_low, mem_high, name, end_condition
             )
@@ -374,10 +371,7 @@ class HookManager:
 
     def _is_unicorn_hook(self, hook_type):
         if isinstance(hook_type, HookType.MEMORY):
-            if hook_type in [
-                HookType.MEMORY.INTERNAL_READ,
-                HookType.MEMORY.INTERNAL_WRITE,
-            ]:
+            if self.is_internal_mem_hook(hook_type):
                 return False
             return True
 
@@ -476,10 +470,16 @@ class HookManager:
 
         return self._cross_process_hooks[handle]
 
+    def is_internal_mem_hook(self, hook_type):
+        return hook_type in [
+            HookType.MEMORY.INTERNAL_READ,
+            HookType.MEMORY.INTERNAL_WRITE,
+            HookType.MEMORY.INTERNAL_MAP,
+        ]
+
     def _get_hooks(self, hook_type):
         if (
-            hook_type
-            in [HookType.MEMORY.INTERNAL_READ, HookType.MEMORY.INTERNAL_WRITE]
+            self.is_internal_mem_hook(hook_type)
             and not self._internal_mem_hooks_enabled
         ):
             return []


### PR DESCRIPTION
We will be using this to know when to setup the function hook.

We may also need to build a hook on first execution of a memory region for the function hook.
This is because we might know where the pointers for the imported functions are, but we would need to keep track of each of them to know when the relocated value is written. One way of doing this is to hook each of those locations and then redirect hooks to those functions when those pointers are written to.

Another way would be to wait until the main module is executed, which we *assume* would be when the relocations have been finished. 