### PR TITLE
Base socket should return bytes sent in send method

### DIFF
--- a/src/zelos/network/base_socket.py
+++ b/src/zelos/network/base_socket.py
@@ -444,6 +444,7 @@ class RawSocketSimulator:
                             packet[tcp.TCP].seq,
                         )
                     )
+            return len(payload)
         else:
             print("[RawSocketSimulator] Unsupported RAW scan packet:", packet)
 


### PR DESCRIPTION
In other socket implementations, we expect the send calls to return the bytes sent. This is a good default behavior (returning bytes written/sent) anyways.