### PR TITLE
Handle invalid "how" in sys_rt_sigprocmask

### DIFF
--- a/src/zelos/ext/platforms/linux/syscalls/syscalls.py
+++ b/src/zelos/ext/platforms/linux/syscalls/syscalls.py
@@ -1688,7 +1688,8 @@ def sys_rt_sigprocmask(k, p):
             new_signal_mask = old_signal_mask & ~sigset
         elif args.how == 2:  # SIG_SETMASK
             new_signal_mask = sigset
-
+        else: 
+            return SysError.EINVAL
         p.zos.signals.set_signal_mask(new_signal_mask)
 
     # TODO: Attempt to handle any signals that are no longer blocked.


### PR DESCRIPTION
We need to have a faster way to develop tests. I am thinking about writing some stuff to allow building of c tests for individual syscalls, rather than relying on the linux system tests. But for now, at least we have a few here.