### PR TITLE
Update dnslib to >=0.9.17; update pre-commit python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3
         # override until resolved: https://github.com/ambv/black/issues/402
         files: \.pyi?$
         types: []
@@ -12,7 +12,7 @@ repos:
     rev: 3.7.8
     hooks:
       - id: flake8
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.3
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: isort
         additional_dependencies: [toml]
-        language_version: python3.6
+        language_version: python3
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = [
     "capstone==4.0.1",
     "sortedcontainers==2.1.0",
     "verboselogs==1.7",
-    "dnslib==0.9.10",
+    "dnslib>=0.9.17",
     "hexdump==3.3",
     "dpkt==1.9.2",
     "coloredlogs==10.0",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ INSTALL_REQUIRES = [
 ]
 EXTRAS_REQUIRE = {
     "docs": [
+        "docutils==0.16",
         "sphinx==2.4.4",
         "sphinx_rtd_theme",
         "sphinxcontrib-apidoc",


### PR DESCRIPTION
Update

- upgrade dnslib 0.9.10 => 0.9.17; flagged by dependabot
- fix docutils == 0.16; as >=0.17 breaks html docs build
- update pre-commit python3 version, can be any system installed python3