### PR TITLE
Fix mprotect for x86_64; add missing signals; begin updating syscalls for general golang binary support

### DIFF
--- a/src/zelos/engine.py
+++ b/src/zelos/engine.py
@@ -278,7 +278,7 @@ class Engine:
         )
 
     def _first_parse(self, module_path):
-        """ Function to parse an executable """
+        """Function to parse an executable"""
         self.logger.verbose("Parse Main Module")
 
         with open(module_path, "rb") as f:
@@ -423,7 +423,7 @@ class Engine:
         return [insn for insn in self.cs.disasm(bytes(code), address)]
 
     def step(self, count: int = 1) -> None:
-        """ Steps one assembly level instruction """
+        """Steps one assembly level instruction"""
         # You might be tempted to use zebracorn's "count" argument to
         # step. However, printing instruction comments relies on an
         # ad-hoc "post instruction" method.
@@ -587,7 +587,7 @@ class Engine:
         return True
 
     def close(self) -> None:
-        """ Handles the end of the run command """
+        """Handles the end of the run command"""
         for closure in self.hook_manager._get_hooks(HookType._OTHER.CLOSE):
             try:
                 closure()

--- a/src/zelos/ext/platforms/linux/signals.py
+++ b/src/zelos/ext/platforms/linux/signals.py
@@ -215,3 +215,5 @@ class Signal(enum.IntEnum):
     RTSIG29 = 60
     RTSIG30 = 61
     RTSIG31 = 62
+    RTSIG32 = 63
+    RTSIG33 = 64

--- a/src/zelos/ext/platforms/linux/syscalls/syscalls.py
+++ b/src/zelos/ext/platforms/linux/syscalls/syscalls.py
@@ -1856,38 +1856,23 @@ def sys_futex(k, p):
         ]
     )
     operation = args.futex_op & 0xF
-    # print(f"OPERATION: {operation}")
     if operation == 1:
         # Futex wake
-        # This should be implemented through shared memory, but
-        # for now, we will just keep track of futexes in the kernel
+        # This should be implemented through shared memory?
+
         # TODO: The number of waiting threads that will be awoken is
         #       determined by args.val: How to communicate this to the
         #       waiting threads?
         # p.memory.write_uint32(args.uaddr, args.val)
-        # p.scheduler.stop_and_exec(
-        #   "process_swap",
-        #   k.z.processes.schedule_next
-        # )
+
         return 1  # Number of waiters woken
     if operation == 0:
         # Futex wait
         # Will resume when expected value changes
-        if k.futexes.get(args.uaddr, args.val) != args.val:
-            return 0
 
-        # def unpause_when():
-        #     # return p.memory.read_uint32(args.uaddr) != args.val
-        #     if k.futexes.get(args.uaddr, args.val) != args.val:
-        #         # k.futexes[args.uaddr] = args.val
-        #         return True
-        #     return False
-
-        # p.threads.pause_current_thread(condition=unpause_when)
         return 0
     if operation == 9:
         mem_val = p.memory.read_uint32(args.uaddr)
-        # print(mem_val, args.val)
         if mem_val == args.val:
             return 0
         return -1  # They need to be the same when this operation starts

--- a/src/zelos/handles/base_handles.py
+++ b/src/zelos/handles/base_handles.py
@@ -353,7 +353,7 @@ class Handles:
         )
 
     def add_handle(self, handle, handle_num=None, pid=None) -> int:
-        """ Returns the handle id for the handle"""
+        """Returns the handle id for the handle"""
         if pid is None:
             pid = self.processes.current_process.pid
         if handle_num is None:
@@ -484,36 +484,44 @@ class Handles:
         in_handle_num = self.add_handle(in_handle)
         return (out_handle_num, in_handle_num)
 
-    def get_by_name(self, name: str) -> Optional[int]:
+    def get_by_name(
+        self, name: str, pid: Optional[int] = None
+    ) -> Optional[int]:
         """
         Gets the numeric identifier for the first handle that has the
         specified name.
 
         Args:
             name: The name of the handle to retrieve.
+            pid: The id of the process to get the handle from. Defaults
+                 to None (all processes).
 
         Returns:
             The handle number corresponding to the specified name if one
             exists. If no such handle exists, returns None.
         """
-        for handle_num, h in self._all_handles(None):
+        for handle_num, h in self._all_handles(pid):
             if h.Name == name:
                 return handle_num
         return None
 
-    def get_by_type(self, class_type: type) -> List[Handle]:
+    def get_by_type(
+        self, class_type: type, pid: Optional[int] = None
+    ) -> List[Handle]:
         """
         Returns all handles of the given type.
 
         Args:
             class_type: Specifies the type that all returned handles
                 should be an instance of.
+            pid: The id of the process to get the handle from. Defaults
+                 to None (all processes).
 
         Returns:
             All handles that are an instance of the specified type.
         """
         return [
-            h for _, h in self._all_handles(None) if isinstance(h, class_type)
+            h for _, h in self._all_handles(pid) if isinstance(h, class_type)
         ]
 
     def get_by_parent_thread(

--- a/src/zelos/memory.py
+++ b/src/zelos/memory.py
@@ -607,7 +607,9 @@ class Memory:
         # return
         if self.disableNX:
             prot = prot | ProtType.EXEC
-        aligned_address = address & 0xFFFFF000  # Address needs to align with
+        aligned_address = (
+            address & 0xFFFFFFFFFFFFF000
+        )  # Address needs to align with
         aligned_size = util.align((address & 0xFFF) + size)
         try:
             self.emu.mem_protect(aligned_address, aligned_size, prot)
@@ -748,11 +750,11 @@ class Memory:
         return mr.prot & ProtType.WRITE != 0
 
     def get_region(self, address: int) -> Optional[MemoryRegion]:
-        """ Gets the region that this address belongs to."""
+        """Gets the region that this address belongs to."""
         return self.emu.mem_region(address)
 
     def get_regions(self):
-        """ Returns a list of all mapped memory regions."""
+        """Returns a list of all mapped memory regions."""
         return self.emu.mem_regions()
 
     def read_ptr(self, addr: int) -> int:
@@ -911,7 +913,7 @@ class Memory:
 
 
 class _HeapObjInfo:
-    """ Information on a heap object. """
+    """Information on a heap object."""
 
     def __init__(
         self,
@@ -971,7 +973,7 @@ class _HeapObjInfo:
 
 
 class Heap:
-    """ Helper class to manage heap allocation."""
+    """Helper class to manage heap allocation."""
 
     def __init__(self, memory, heap_start, heap_max_size):
         self.memory = memory

--- a/src/zelos/processes.py
+++ b/src/zelos/processes.py
@@ -151,6 +151,7 @@ class Process:
             module_path=module_path,
             benign_code=benign_code,
         )
+        t.parent_id = self.pid
 
         current_thread = self.current_thread
         self.threads._swap_thread(t.id)
@@ -216,7 +217,7 @@ class Process:
 
 
 class Processes:
-    """ Exposes the processes that are on the virtual machine."""
+    """Exposes the processes that are on the virtual machine."""
 
     def __init__(
         self,

--- a/src/zelos/threads.py
+++ b/src/zelos/threads.py
@@ -636,7 +636,7 @@ class Threads:
         return new_thread
 
     def change_thread_priority(self, thread_name, new_priority):
-        """ Change the priority of a thread"""
+        """Change the priority of a thread"""
         t = self.get_thread_by_name(thread_name)
         if t is None:
             print("Unable to find thread %s" % thread_name)
@@ -644,11 +644,11 @@ class Threads:
         t.priority = new_priority
 
     def get_all_threads(self) -> List[Thread]:
-        """ Returns all threads, whether active or stopped"""
+        """Returns all threads, whether active or stopped"""
         return self.thread_list[:]
 
     def get_thread_by_name(self, name: str) -> Optional[Thread]:
-        """ Returns the first thread with the given name """
+        """Returns the first thread with the given name"""
         threads = self.get_threads([name])
         return threads[0] if len(threads) > 0 else None
 
@@ -745,7 +745,7 @@ class Threads:
             hook(old_thread)
 
     def _load(self, thread):
-        """ Loads the specified thread into the emulator """
+        """Loads the specified thread into the emulator"""
         if thread is None:
             self.current_thread = None
             return

--- a/tests/tools/test_zdbserver.py
+++ b/tests/tools/test_zdbserver.py
@@ -151,7 +151,7 @@ class TestZdbServer(unittest.TestCase):
 
             # Test memory map list
             mappings = zdb.get_mappings()
-            self.assertEqual(len(mappings), 21)
+            self.assertEqual(len(mappings), 22)
             mr = mappings[0]
             self.assertTrue("start_address" in mr)
             self.assertTrue("end_address" in mr)


### PR DESCRIPTION
- Fix bug in `mprotect` to properly handle 64bit addressing
- Add missing signals
- Hook & return from attempts to invoke virtual syscalls
- Begin updating `clone` & `futex` syscalls for golang startup behavior