### PR TITLE
Interpreter value seems to have changed in lief

### DIFF
--- a/src/zelos/ext/platforms/linux/parse.py
+++ b/src/zelos/ext/platforms/linux/parse.py
@@ -36,10 +36,11 @@ class LiefELF(ParsedBinary):
         return "ELF"
 
     def _get_interpreter(self, binary):
-        try:
-            return binary.interpreter
-        except Exception:
+        if not hasattr(binary, "interpreter"):
             return None
+        if binary.interpreter is None or binary.interpreter == "":
+            return None
+        return binary.interpreter
 
     def _find_interpreter(self, requested_interpreter, binary):
         if requested_interpreter == "":


### PR DESCRIPTION
Static binaries may have an empty string instead of just missing the interpreter value